### PR TITLE
Implement catPA

### DIFF
--- a/vllm/hpu/ops.py
+++ b/vllm/hpu/ops.py
@@ -34,8 +34,15 @@ def gelu_fast(output, input):
     raise NotImplementedError
 
 
-def fetch_from_cache(cache, blocks, permutations):
-    return [cache.index_select(0, blocks[:, i]).permute(permutations) for i in range(blocks.size(1))]
+def fetch_from_cache(cache, blocks, seq_len, query_heads, kv_heads, permutations):
+    blocks_list = blocks.flatten()
+    data = cache.index_select(0, blocks_list)
+    if seq_len > 1:
+        data = data.view(blocks.shape[0], -1, cache.shape[2], cache.shape[3])
+    data = data.permute(permutations)
+    if query_heads != kv_heads:
+        data = data.unflatten(1, (kv_heads, 1))
+    return data
 
 
 @hpu_utils.with_mark_steps
@@ -49,33 +56,19 @@ def paged_attention_v1(query, key_cache, value_cache, head_mapping, scale, block
             .expand(batch_size, -1)
             .ge(context_lens.view(-1, 1))
             .view(batch_size, 1, 1, -1))
-    query.mul_(scale)
     query = query.unsqueeze(-2)
-    keys = fetch_from_cache(key_cache, block_tables, (0, 2, 3, 1))
     if query_heads != kv_heads:
         query = query.unflatten(1, (kv_heads, -1))
-        keys = [k.unflatten(1, (kv_heads, 1)) for k in keys]
         mask = mask.unsqueeze(2)
 
-    attn_weights = [torch.matmul(query, k) for k in keys]
-    attn_weights = (torch.cat(attn_weights, dim=-1)
-                    .masked_fill(mask, min_inf)
-                    .softmax(dim=-1))
-
-    values = fetch_from_cache(value_cache, block_tables, (0, 2, 1, 3))
-    if PA_SPLIT_VALUE:
-        attn_weights = attn_weights.split(block_size, dim=-1)
-    else:
-        values = [torch.cat(values, dim=-2)]
-        attn_weights = [attn_weights]
+    keys = fetch_from_cache(key_cache, block_tables, seq_len, query_heads, kv_heads, (0, 2, 3, 1))
+    attn_weights = torch.matmul(query, keys).mul_(scale).masked_fill(mask, min_inf).softmax(dim=-1)
+    values = fetch_from_cache(value_cache, block_tables, seq_len, query_heads, kv_heads, (0, 2, 1, 3))
+    attn_weights = torch.matmul(attn_weights, values).squeeze(-2)
     if query_heads != kv_heads:
-        values = [v.unflatten(1, (kv_heads, 1)) for v in values]
-    attn_weights = [torch.matmul(a, v) for a, v in zip(attn_weights, values)]
-    if query_heads != kv_heads:
-        attn_weights = [a.flatten(1, 2) for a in attn_weights]
-    attn_weights = sum(attn_weights)
-    return attn_weights.squeeze(-2)
+        attn_weights = attn_weights.flatten(1, 2)
 
+    return attn_weights
 
 def rms_norm(out, hidden_states, weight, eps):
     htorch.core.mark_step()

--- a/vllm/hpu/ops.py
+++ b/vllm/hpu/ops.py
@@ -14,10 +14,6 @@ from typing import List, Optional, Tuple
 
 import vllm.hpu.utils as hpu_utils
 
-# FIXME: For some reason splitting value causes DFAs on G3. This needs to be debugged
-PA_SPLIT_VALUE_DEFAULT = '0' if (htexp._get_device_type() == htexp.synDeviceType.synDeviceGaudi3) else '1'
-PA_SPLIT_VALUE = (os.environ.get('PA_SPLIT_VALUE', PA_SPLIT_VALUE_DEFAULT) == '1')
-
 
 def silu_and_mul(output, input):
     d = input.shape[-1] // 2


### PR DESCRIPTION
This PR extends from https://github.com/HabanaAI/vllm-fork/pull/56.
In this PR, we propose to concatenate fetched KV cache before the multiplication with Q. This may improve the MME utilization for inference cases with smaller batch or smaller block size.

We can reshape cache fetched with index_select to (batch, num_heads, head_dim, seq_len*block_size) with single view() and permute() for two reasons:

The layout of KV cache became (num_blocks, block_size, num_heads, head_dim) after https://github.com/HabanaAI/vllm-fork/pull/56.
block_tables is always rectangular - 0 is padded for requests with shorter KV history.
We are observing overall throughput gain for diverse inference scenarios (1K~8K input sequence length with 1K output sequence length for both Llama-3-8B with 1 card and Llama-3-70B with 8 cards).
While, it underperforms current implementation for some cases such as 1K random input / 1K output without eos, 256 max-num-seqs, 128 block-size, enforce-eager.  We guess that in such cases, MME utilization can be already high since the batch size and block size are large enough even without concatenation.

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


