### PR TITLE
feat: use 1d query for prefill

### DIFF
--- a/vllm/attention/backends/habana_attn.py
+++ b/vllm/attention/backends/habana_attn.py
@@ -102,6 +102,9 @@ class HabanaAttentionMetadata(AttentionMetadataPerStage, HabanaPagedAttentionMet
     # TODO(woosuk): Move `use_cuda_graph` out since it's unrelated to attention.
     use_cuda_graph: bool
 
+    # Maximum sequence length in the batch.
+    max_seq_len: Optional[int] = None
+
     def __post_init__(self):
         # Set during the execution of the first attention op.
         # It is a list because it is needed to set per prompt

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -591,6 +591,7 @@ class SchedulerConfig:
             prompt latency) before scheduling next prompt.
         enable_chunked_prefill: If True, prefill requests can be chunked based
             on the remaining max_num_batched_tokens.
+        enable_1d_query: If True, use 1d query throughout the forward process
     """
 
     def __init__(
@@ -602,6 +603,7 @@ class SchedulerConfig:
         num_lookahead_slots: int = 0,
         delay_factor: float = 0.0,
         enable_chunked_prefill: bool = False,
+        enable_1d_query: bool = False,
     ) -> None:
         if max_num_batched_tokens is not None:
             self.max_num_batched_tokens = max_num_batched_tokens
@@ -623,6 +625,12 @@ class SchedulerConfig:
         self.num_lookahead_slots = num_lookahead_slots
         self.delay_factor = delay_factor
         self.chunked_prefill_enabled = enable_chunked_prefill
+        self.enable_1d_query = enable_1d_query
+        if self.chunked_prefill_enabled and not self.enable_1d_query:
+            raise NotImplementedError(
+                "chunked-prefill with 2d query is not implemented. "
+                "Enable enable_1d_query to use chunked-prefill."
+            )
 
         self._verify_args()
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -37,7 +37,7 @@ class EngineArgs:
     pipeline_parallel_size: int = 1
     tensor_parallel_size: int = 1
     max_parallel_loading_workers: Optional[int] = None
-    block_size: int = 16
+    block_size: int = 128
     enable_prefix_caching: bool = False
     use_v2_block_manager: bool = False
     swap_space: int = 4  # GiB
@@ -69,6 +69,7 @@ class EngineArgs:
     num_gpu_blocks_override: Optional[int] = None
     num_lookahead_slots: int = 0
     model_loader_extra_config: Optional[dict] = None
+    enable_1d_query: bool = False
 
     # Related to Vision-language models such as llava
     image_input_type: Optional[str] = None
@@ -564,6 +565,7 @@ class EngineArgs:
                                  speculative_config.num_lookahead_slots),
             delay_factor=self.scheduler_delay_factor,
             enable_chunked_prefill=self.enable_chunked_prefill,
+            enable_1d_query=self.enable_1d_query,
         )
         lora_config = LoRAConfig(
             max_lora_rank=self.max_lora_rank,


### PR DESCRIPTION
Use 1d query throughout the forward path for prefill phase.
It is required to implement chunked-prefill. By using 1d query, we can also reduce the number of zero padding for input sequences, allowing higher HPU utilization.  
Whereas the original vllm uses 1d query as default (even without chunking), It's implemented as optional in this PR with `enable_1d_query` parameter in `SchedulerConfig`.
