### PR TITLE
Integrate prefill-chunking and piggybacking

### DIFF
--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -110,7 +110,6 @@ def run_vllm(
     max_num_batched_tokens: int,
     gpu_memory_utilization: float = 0.9,
     download_dir: Optional[str] = None,
-    enable_1d_query: Optional[bool] = False,
     enable_piggybacking: Optional[bool] = False,
     use_text_input: Optional[bool] = False,
     print_outputs: Optional[bool] = False,
@@ -134,7 +133,6 @@ def run_vllm(
         download_dir=download_dir,
         enable_chunked_prefill=enable_chunked_prefill,
         max_num_batched_tokens=max_num_batched_tokens,
-        enable_1d_query=enable_1d_query,
         enable_piggybacking=enable_piggybacking,
     )
 
@@ -271,7 +269,7 @@ def main(args: argparse.Namespace):
             args.quantization_param_path, args.device,
             args.enable_prefix_caching, args.enable_chunked_prefill,
             args.max_num_batched_tokens, args.gpu_memory_utilization,
-            args.download_dir, args.enable_1d_query, args.enable_piggybacking, 
+            args.download_dir, args.enable_piggybacking, 
             args.use_text_input, args.print_outputs)
     elif args.backend == "hf":
         assert args.tensor_parallel_size == 1
@@ -394,9 +392,6 @@ if __name__ == "__main__":
     parser.add_argument("--enable-chunked-prefill",
                         action='store_true',
                         help="enable chunked prefill for vLLM backend.")
-    parser.add_argument("--enable-1d-query",
-                        action='store_true',
-                        help="If true, use 1d query instead of 2d query.")
     parser.add_argument("--enable-piggybacking",
                         action='store_true',
                         help="If true, use piggybacking instead of separating prefills and decodes.")

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -159,7 +159,8 @@ def run_vllm(
     else:
         outputs = llm.generate(prompt_token_ids=prompts, sampling_params=sampling_params, use_tqdm=True)
     if print_outputs:
-        print(f"Outputs: {outputs[0].outputs[0].text}, {outputs[0].outputs[0].token_ids}")
+        for output in outputs:
+            print(f"Outputs: {output.outputs[0].text}, {output.outputs[0].token_ids}")
     end = time.perf_counter()
     elapsed_time = end - start
     return outputs, elapsed_time

--- a/vllm/attention/backends/habana_attn.py
+++ b/vllm/attention/backends/habana_attn.py
@@ -213,8 +213,8 @@ class HabanaAttentionImpl(AttentionImpl):
             # TODO(minkyu): refactor this condition branch when prefill chunking is enabled
                 # TODO: move this outside of model
                 assert prefill_meta.attn_bias is not None, 'attn_bias must be set before calling model.forward!'
-                query_shape = (batch_size, num_prefill_tokens, self.num_heads, self.head_size)
-                kv_shape = (batch_size, num_prefill_tokens, self.num_kv_heads, self.head_size)
+                query_shape = (batch_size, -1, self.num_heads, self.head_size)
+                kv_shape = (batch_size, -1, self.num_kv_heads, self.head_size)
                 out = xops.prompt_attention(
                     prompt_query.view(query_shape),
                     prompt_key.view(kv_shape),
@@ -223,7 +223,7 @@ class HabanaAttentionImpl(AttentionImpl):
                     p=0.0,
                     scale=self.scale,
                 )
-                prompt_output = out.reshape(batch_size, num_prefill_tokens, hidden_size)
+                prompt_output = out.reshape(batch_size, -1, hidden_size)
             else:
                 # prefix-enabled attention
                 output = HabanaPagedAttention.forward_prefix(

--- a/vllm/attention/backends/habana_attn.py
+++ b/vllm/attention/backends/habana_attn.py
@@ -232,8 +232,6 @@ class HabanaAttentionImpl(AttentionImpl):
                         self.num_heads,
                         self.num_kv_heads
                     )
-                    # TODO(minkyu): concat should follow the mask.
-                    # Consider modifing the mask side to always have the past kv at front.
                     key = torch.cat((past_key.squeeze(0)[:context_len], key))
                     value = torch.cat((past_value.squeeze(0)[:context_len], value))
                     kv_shape = (batch_size, seq_len_kv + context_len, self.num_kv_heads, self.head_size)

--- a/vllm/attention/backends/habana_attn.py
+++ b/vllm/attention/backends/habana_attn.py
@@ -105,6 +105,9 @@ class HabanaAttentionMetadata(AttentionMetadataPerStage, HabanaPagedAttentionMet
     # Maximum sequence length in the batch.
     max_seq_len: Optional[int] = None
 
+    # A tensor of query lengths is the current chunk
+    query_lens_tensor: Optional[torch.Tensor] = None
+
     def __post_init__(self):
         # Set during the execution of the first attention op.
         # It is a list because it is needed to set per prompt

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -929,7 +929,7 @@ class Scheduler:
     def _schedule(self) -> SchedulerOutputs:
         """Schedule queued requests."""
         if self.scheduler_config.chunked_prefill_enabled:
-            return self._schedule_chunked_prefill(self.scheduler_config.enable_piggybacking)
+            return self._schedule_chunked_prefill(self.scheduler_config.piggybacking_enabled)
         else:
             return self._schedule_default()
 

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -112,7 +112,7 @@ class ScheduledSequenceGroup:
 class SchedulerOutputs:
     """The scheduling decision made from a scheduler."""
     # Scheduled sequence groups.
-    scheduled_seq_groups: Iterable[ScheduledSequenceGroup]
+    scheduled_seq_groups: Iterable[SequenceGroup | ScheduledSequenceGroup]
     # Number of prefill groups scheduled.
     num_prefill_groups: int
     # Total number of batched tokens.
@@ -637,7 +637,7 @@ class Scheduler:
             SchedulerSwappedInOutputs.
         """
         ignored_seq_groups: List[SequenceGroup] = []
-        seq_groups: List[SequenceGroup] = []
+        seq_groups: List[SequenceGroup | ScheduledSequenceGroup] = []
         # We don't sort waiting queue because we assume it is sorted.
         # Copy the queue so that the input queue is not modified.
         waiting_queue = deque([s for s in waiting_queue])

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -908,9 +908,9 @@ class Scheduler:
                 f"decodes: {len(running_scheduled.decode_seq_groups)}, {len(swapped_in.decode_seq_groups)}")
 
         return SchedulerOutputs(
-            scheduled_seq_groups=(prefills.seq_groups +
-                                  running_scheduled.prefill_seq_groups +
+            scheduled_seq_groups=(running_scheduled.prefill_seq_groups +
                                   swapped_in.prefill_seq_groups +
+                                  prefills.seq_groups +
                                   running_scheduled.decode_seq_groups +
                                   swapped_in.decode_seq_groups),
             num_prefill_groups=(len(prefills.seq_groups) +

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -69,7 +69,6 @@ class EngineArgs:
     num_gpu_blocks_override: Optional[int] = None
     num_lookahead_slots: int = 0
     model_loader_extra_config: Optional[dict] = None
-    enable_1d_query: bool = False
     enable_chunked_prefill: bool = False
     enable_piggybacking: bool = False
 
@@ -567,7 +566,6 @@ class EngineArgs:
             delay_factor=self.scheduler_delay_factor,
             enable_chunked_prefill=self.enable_chunked_prefill,
             enable_piggybacking=self.enable_piggybacking,
-            enable_1d_query=self.enable_1d_query,
         )
         lora_config = LoRAConfig(
             max_lora_rank=self.max_lora_rank,

--- a/vllm/hpu/ops.py
+++ b/vllm/hpu/ops.py
@@ -30,14 +30,15 @@ def gelu_fast(output, input):
     raise NotImplementedError
 
 
-def fetch_from_cache(cache, blocks, seq_len, query_heads, kv_heads, permutations):
+def fetch_from_cache(cache, blocks, seq_len, query_heads, kv_heads, permutations = None):
     blocks_list = blocks.flatten()
     data = cache.index_select(0, blocks_list)
     if seq_len > 1:
         data = data.view(blocks.shape[0], -1, cache.shape[2], cache.shape[3])
-    data = data.permute(permutations)
-    if query_heads != kv_heads:
-        data = data.unflatten(1, (kv_heads, 1))
+    if permutations is not None:
+        data = data.permute(permutations)
+        if query_heads != kv_heads:
+            data = data.unflatten(1, (kv_heads, 1))
     return data
 
 

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -358,9 +358,9 @@ class HabanaModelRunner:
         self,
         seq_group_metadata_list: List[SequenceGroupMetadata],
     ) -> PreparePromptMetadata:
-        input_tokens: List[List[int]] = []
-        input_positions: List[List[int]] = []
-        slot_mapping: List[List[int]] = []
+        input_tokens: List[List[int]] | torch.Tensor= []
+        input_positions: List[List[int]] | torch.Tensor= []
+        slot_mapping: List[List[int]] | torch.Tensor= []
         lora_index_mapping: List[List[int]] = []
         lora_prompt_mapping: List[List[int]] = []
         lora_requests: Set[LoRARequest] = set()
@@ -390,6 +390,7 @@ class HabanaModelRunner:
                     "now.")
 
             token_chunk_size = seq_group_metadata.token_chunk_size
+            assert token_chunk_size is not None
             seq_data = seq_group_metadata.seq_data[seq_id]
             context_len = seq_data.get_num_computed_tokens()
             # We should use get_len here because in case of preemption
@@ -561,9 +562,9 @@ class HabanaModelRunner:
         self,
         seq_group_metadata_list: List[SequenceGroupMetadata],
     ) -> PreparePromptMetadata:
-        input_tokens: List[int] = []
-        input_positions: List[int] = []
-        slot_mapping: List[int] = []
+        input_tokens: List[int] | torch.Tensor= []
+        input_positions: List[int] | torch.Tensor= []
+        slot_mapping: List[int] | torch.Tensor= []
         lora_index_mapping: List[int] = []
         lora_prompt_mapping: List[int] = []
         lora_requests: Set[LoRARequest] = set()
@@ -593,6 +594,7 @@ class HabanaModelRunner:
                     "now.")
 
             token_chunk_size = seq_group_metadata.token_chunk_size
+            assert token_chunk_size is not None
             seq_data = seq_group_metadata.seq_data[seq_id]
             context_len = seq_data.get_num_computed_tokens()
             # We should use get_len here because in case of preemption
@@ -812,7 +814,7 @@ class HabanaModelRunner:
                                              self.block_size)
                     block_table = block_table[-sliding_window_blocks:]
                 block_tables.append(block_table)
-            
+        
         # convert inputs to tensor for HPU compatibility
         input_tokens = torch.tensor(input_tokens, dtype=torch.long, device=self.device)
         input_positions = torch.tensor(input_positions, dtype=torch.long, device=self.device)

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -134,12 +134,12 @@ class HpuModelAdapter():
                 #FIXME: Restore sliding window support
                 #if self.sliding_window is not None:
             else:
+                # TODO(minkyu): benchmark overheads
                 prompt_lens_t = prefill_metadata.query_lens_tensor
                 context_lens_t = prefill_metadata.context_lens_tensor
                 assert seq_len == torch.sum(prompt_lens_t)
                 assert prompt_lens_t.size() == context_lens_t.size()
                 assert batch_size == 1
-                # TODO(minkyu): check masks when input has padding
                 cur_masks = [torch.tril(torch.ones((size, size), device=device, dtype=torch.bool)) for size in prompt_lens_t]
                 past_masks = [torch.ones((q_len, past_kv_len), device=device, dtype=torch.bool) for q_len, past_kv_len in zip(prompt_lens_t, context_lens_t)]
                 masks_per_prompt = [torch.cat((past, cur), dim=1) for past, cur in zip(past_masks, cur_masks)]

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -174,7 +174,6 @@ class HpuModelAdapter():
             torch.bfloat16,
             enable_1d_query=enable_1d_query,
         )
-        print(f"input_shape!!! {kwargs['input_ids'].shape}, {kwargs['kv_caches'][0][0].shape if kwargs['kv_caches'][0] is not None else None}, {selected_token_indices}")
         hidden_states = self.model(*args, **kwargs)
         hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
         hidden_states = hidden_states.index_select(0, selected_token_indices)

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -119,6 +119,7 @@ class HpuModelAdapter():
         #if self.alibi_slopes is None:
         if True:
             if not enable_1d_query:
+                seq_len = seq_len // batch_size
                 seq_lens_t = prefill_metadata.seq_lens_tensor
                 len_mask = (torch.arange(0, seq_len, device=device, dtype=torch.int32)
                             .view(1, seq_len)


### PR DESCRIPTION
Chunked-prefill now operates on vllm-fork. It can be enabled with `--enable-chunked-prefill` and `--enable-piggybacking`. These two flags should be integrated after testing prefill-chunking only. When piggybacking is enabled, RUNNING sequences are scheduled first as much as remaining slots allow, which follows the policy of the original vllm. 
- Checked functionality with the possible chunking scenarios(1.splitting a sequence into chunks, 2.merging sequences into a chunk, 3. mix of them), together with decode batches.
- Restored `max_num_batched_tokens` value to the default value, 512.

Example command: `VLLM_SKIP_WARMUP=true python benchmarks/benchmark_throughput.py --model /models/Meta-Llama-3-8B-Instruct/ --num-prompts 4 --print-outputs --input-len 1024 --output-len 3 --enable-chunked-prefill --enable-piggybacking`.

TODO
- hyper-parameter-ize chunked-prefill related configurations
- handle preemption
- add padding to the chunk size
- analyze hpu graph and setup warmups