### PR TITLE
1d prefill

### DIFF
--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -117,6 +117,7 @@ def run_vllm(
     enable_piggybacking: Optional[bool] = False,
     use_text_input: Optional[bool] = False,
     print_outputs: Optional[bool] = False,
+    enable_1d_prefill: Optional[bool] = False,
 ) -> float:
     from vllm import LLM, SamplingParams
     llm = LLM(
@@ -140,6 +141,7 @@ def run_vllm(
         distributed_executor_backend=distributed_executor_backend,
         load_format=load_format,
         enable_piggybacking=enable_piggybacking,
+        enable_1d_prefill=enable_1d_prefill,
     )
 
     # Add the requests to the engine.
@@ -276,7 +278,7 @@ def main(args: argparse.Namespace):
             args.enable_prefix_caching, args.enable_chunked_prefill,
             args.max_num_batched_tokens, args.distributed_executor_backend,
             args.gpu_memory_utilization, args.download_dir, args.load_format, args.enable_piggybacking, 
-            args.use_text_input, args.print_outputs)
+            args.use_text_input, args.print_outputs, args.enable_1d_prefill)
     elif args.backend == "hf":
         assert args.tensor_parallel_size == 1
         elapsed_time = run_hf(requests, args.model, tokenizer, args.n,
@@ -408,6 +410,9 @@ if __name__ == "__main__":
         "--enable-prefix-caching",
         action='store_true',
         help="enable automatic prefix caching for vLLM backend.")
+    parser.add_argument("--enable-1d-prefill",
+                        action='store_true',
+                        help="use 1d query throughout the prefill phase.")
     parser.add_argument("--enable-chunked-prefill",
                         action='store_true',
                         help="enable chunked prefill for vLLM backend.")

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -706,6 +706,7 @@ class SchedulerConfig:
             accepted.
         delay_factor: Apply a delay (of delay factor multiplied by previous
             prompt latency) before scheduling next prompt.
+        enable_1d_prefill: If True, use 1d query throughout the prefill phase.
         enable_chunked_prefill: If True, prefill requests can be chunked based
             on the remaining max_num_batched_tokens.
         enable_piggybacking: If True, schedule prefill sequences and 
@@ -726,13 +727,17 @@ class SchedulerConfig:
                  use_v2_block_manager: bool = False,
                  num_lookahead_slots: int = 0,
                  delay_factor: float = 0.0,
+                 enable_1d_prefill: bool = False,
                  enable_chunked_prefill: bool = False,
                  enable_piggybacking: bool = False,
                  embedding_mode: Optional[bool] = False,
                  preemption_mode: Optional[str] = None) -> None:
+        if enable_chunked_prefill and not enable_1d_prefill:
+            enable_1d_prefill = True
         if enable_piggybacking and not enable_chunked_prefill:
             # This warning can be removed after integrating enable_chunked_prefill and enable_piggybacking flags.
             logger.warning("Setting enable_chunked_prefill to True to enable piggybacking.")
+            enable_1d_prefill = True
             enable_chunked_prefill = True
 
         if max_num_batched_tokens is not None:
@@ -758,6 +763,7 @@ class SchedulerConfig:
         self.use_v2_block_manager = use_v2_block_manager
         self.num_lookahead_slots = num_lookahead_slots
         self.delay_factor = delay_factor
+        self.enable_1d_prefill = enable_1d_prefill
         self.chunked_prefill_enabled = enable_chunked_prefill
         self.embedding_mode = embedding_mode
         self.preemption_mode = preemption_mode

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -77,6 +77,7 @@ class EngineArgs:
     num_lookahead_slots: int = 0
     model_loader_extra_config: Optional[dict] = None
     preemption_mode: Optional[str] = None
+    enable_1d_prefill: bool = False
     enable_chunked_prefill: bool = False
     enable_piggybacking: bool = False
 
@@ -741,6 +742,7 @@ class EngineArgs:
                                  if speculative_config is None else
                                  speculative_config.num_lookahead_slots),
             delay_factor=self.scheduler_delay_factor,
+            enable_1d_prefill=self.enable_1d_prefill,
             enable_chunked_prefill=self.enable_chunked_prefill,
             embedding_mode=model_config.embedding_mode,
             preemption_mode=self.preemption_mode,


### PR DESCRIPTION
Restored `enable_1d_prefill` (without chunking) flag.
- Input sequences are concatenated into (1, sum of seqlens) tensor and attention will be performed with the correspondingly formed mask.
- Currently there's no padding after the concatenation.

There are 3 flags that can be enabled in the following order: `enable_1d_prefill`, `enable_chunked_prefill` and `enable_piggybacking`. When enabling the latter flags, the former flags will be enabled as well. 
