### PR TITLE
skip profile run and warmup

### DIFF
--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -1398,7 +1398,7 @@ class HabanaModelRunner:
     @torch.inference_mode()
     def warmup_model(self, kv_caches: List[torch.Tensor]) -> None:
         # fix(huijong): just skip warmup for now
-        if self.scheduler_config.chunked_prefill_enabled or os.environ.get('VLLM_SKIP_WARMUP', 'false').lower() == 'true':
+        if self.scheduler_config.enable_1d_prefill or os.environ.get('VLLM_SKIP_WARMUP', 'false').lower() == 'true':
             logger.info("Skipping warmup...")
             return
         self.profiler.start('internal', 'warmup')

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -1397,7 +1397,8 @@ class HabanaModelRunner:
 
     @torch.inference_mode()
     def warmup_model(self, kv_caches: List[torch.Tensor]) -> None:
-        if os.environ.get('VLLM_SKIP_WARMUP', 'false').lower() == 'true':
+        # fix(huijong): just skip warmup for now
+        if self.scheduler_config.chunked_prefill_enabled or os.environ.get('VLLM_SKIP_WARMUP', 'false').lower() == 'true':
             logger.info("Skipping warmup...")
             return
         self.profiler.start('internal', 'warmup')

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -1307,7 +1307,16 @@ class HabanaModelRunner:
         max_batch_size = self.prompt_bs_bucket_cfg[-1]
         max_seq_len = self.prompt_seq_bucket_cfg[-1]
 
+        # Disable chunked prefill to capture maximum workspace
+        enable_1d_prefill = self.scheduler_config.enable_1d_prefill
+        chunked_prefill_enabled = self.scheduler_config.chunked_prefill_enabled
+        self.scheduler_config.enable_1d_prefill = False
+        self.scheduler_config.chunked_prefill_enabled = False
+
         self.warmup_scenario(max_batch_size, max_seq_len, True, kv_caches)
+
+        self.scheduler_config.enable_1d_prefill = enable_1d_prefill
+        self.scheduler_config.chunked_prefill_enabled = chunked_prefill_enabled
 
     def warmup_scenario(self, batch_size, seq_len, is_prompt,
                         kv_caches) -> None:

--- a/vllm/worker/habana_worker.py
+++ b/vllm/worker/habana_worker.py
@@ -132,7 +132,7 @@ class HabanaWorker(WorkerBase):
         cache_block_size = self.get_cache_block_size_bytes()
         graph_headroom = 1 - (float(
             os.environ.get('VLLM_GRAPH_RESERVED_MEM', '0.4'))
-                              if not self.model_config.enforce_eager else 0)
+                              if not self.model_config.enforce_eager and not self.scheduler_config.chunked_prefill_enabled else 0)
         num_hpu_blocks = int(free_hpu_memory * graph_headroom *
                              self.cache_config.gpu_memory_utilization //
                              cache_block_size)

--- a/vllm/worker/habana_worker.py
+++ b/vllm/worker/habana_worker.py
@@ -116,11 +116,7 @@ class HabanaWorker(WorkerBase):
         .. tip::
             You may limit the usage of GPU memory
             by adjusting the `gpu_memory_utilization` parameter.
-        """
-        if self.scheduler_config.chunked_prefill_enabled:
-            # TODO(huijong): restore original functionality
-            return 2579, 256
-     
+        """     
         # Profile the memory usage of the model and get the maximum number of
         # cache blocks that can be allocated with the remaining free memory.
 


### PR DESCRIPTION
The block numbers we were using(2580) was the block numbers that we get when we reserve 40% of memory for HPUGraphs. Without it you should get 4300.

Refer to this draft to skip initialization process(profile run and warmup) for chunked prefill.
It may slow down a little, but critical errors won't occur.


